### PR TITLE
standings with tiebreaker displayed

### DIFF
--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -40,7 +40,7 @@ class Navigation extends React.Component {
     return (
       <Container>
       <div>
-        <Navbar expand="lg" defaultExpanded={isMobile} collapseOnSelect={true}> 
+        <Navbar expand="lg" defaultExpanded={false} collapseOnSelect={true}> 
           <Navbar.Brand href="/tournaments" onClick={() => setExpanded(true)}>Major Tournament Pick Six</Navbar.Brand>
           <Navbar.Toggle aria-controls="basic-navbar-nav" onClick={() => setExpanded(!expanded)}/>
           <Navbar.Collapse id="basic-navbar-nav">

--- a/src/components/standings.js
+++ b/src/components/standings.js
@@ -36,7 +36,7 @@ class Standings extends React.Component {
                         {x.team} ({formatscore(x.score[0] + x.score[1])})
                      </center>
                     </Accordion.Header>
-                    <PlayerLayout team={x.team} results={this.state.results} players={this.state.teams.get(x.team)}/>
+                    <PlayerLayout team={x.team} results={this.state.results} players={this.state.teams.get(x.team)} tiebreaker={x.tiebreaker}/>
                     </Accordion.Item>
                 ))
             }    
@@ -132,6 +132,8 @@ function PlayerLayout(props) {
     });
     //console.log(team,results);
 
+    const tiebreaker = [ 'Last', 'Better Score', 'Third Place', 'Fourth Place', 'Fifth Place', 'Sixth Place' ];
+
     return (
         <Accordion.Body>
         <Table striped bordered size="sm">
@@ -158,6 +160,7 @@ function PlayerLayout(props) {
             }
             </tbody>
         </Table>
+        <div><font size="2">Position Tiebreaker : {tiebreaker[Math.abs(props.tiebreaker)]}</font></div>
         </Accordion.Body>
     );
 }


### PR DESCRIPTION
mobile is not expanded by default

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
